### PR TITLE
support inheritance

### DIFF
--- a/bundler-compiler/src/main/java/in/workarounds/bundler/compiler/util/names/ClassProvider.java
+++ b/bundler-compiler/src/main/java/in/workarounds/bundler/compiler/util/names/ClassProvider.java
@@ -16,6 +16,7 @@ public class ClassProvider {
 
     private static String bundlerPackage = null;
 
+    public static final ClassName object = ClassName.get(Object.class);
     public static final ClassName serializer = ClassName.get(Serializer.class);
     public static final ClassName bundlerUtils = ClassName.get(Utils.class);
 
@@ -23,6 +24,10 @@ public class ClassProvider {
     public static final ClassName context = ClassName.get("android.content", "Context");
     public static final ClassName bundle = ClassName.get("android.os", "Bundle");
     public static final ClassName intent = ClassName.get("android.content", "Intent");
+    public static final ClassName activity = ClassName.get("android.app", "Activity");
+    public static final ClassName fragment = ClassName.get("android.app", "Fragment");
+    public static final ClassName fragmentV4 = ClassName.get("android.support.v4.app", "Fragment");
+    public static final ClassName service = ClassName.get("android.app", "Service");
 
     public static ClassName helper(ReqBundlerModel model) {
         return ClassName.bestGuess(model.getPackageName() + "." + model.getSimpleName() + "Bundler");

--- a/bundler-compiler/src/main/java/in/workarounds/bundler/compiler/util/names/VarName.java
+++ b/bundler-compiler/src/main/java/in/workarounds/bundler/compiler/util/names/VarName.java
@@ -14,6 +14,12 @@ public class VarName {
     public static final String context = from(ClassProvider.context);
     public static final String intent  = from(ClassProvider.intent);
 
+    public static final String object = from(ClassProvider.object);
+    public static final String activity = from(ClassProvider.activity);
+    public static final String fragment = from(ClassProvider.fragment);
+    public static final String fragmentV4 = from(ClassProvider.fragmentV4);
+    public static final String service = from(ClassProvider.service);
+
     public static final String defaultVal = "defaultVal";
     public static final String parser     = "parser";
 


### PR DESCRIPTION
To avoid override onCreate method in every child class, generate a injection method with object parameter.
In this method, call the appropriate injection method by casting the object to the appropriate class.

Issue #18